### PR TITLE
MarkdownGenerator: present property name as code

### DIFF
--- a/src/Generator/MarkdownGenerator.php
+++ b/src/Generator/MarkdownGenerator.php
@@ -127,7 +127,7 @@ class MarkdownGenerator implements Generator
     private function getPublicPropertyLines(array $properties): array
     {
         return array_map(function (Property $property) {
-            return "- \${$property->getName()} : {$property->getType()} {$property->getDescription()}";
+            return "- `\${$property->getName()}` : {$property->getType()} {$property->getDescription()}";
         }, $properties);
     }
 

--- a/tests/Generator/MarkdownGeneratorTest.php
+++ b/tests/Generator/MarkdownGeneratorTest.php
@@ -72,7 +72,7 @@ class MarkdownGeneratorTest extends TestCase
         );
 
         self::assertEquals(
-            <<<MD
+            <<<'MD'
             # Standard.Category.My
             
             Description
@@ -83,8 +83,8 @@ class MarkdownGeneratorTest extends TestCase
             
             ## Public Properties
             
-            - \$a : string DescriptionA
-            - \$b : int DescriptionB
+            - `$a` : string DescriptionA
+            - `$b` : int DescriptionB
             
             ## See Also
             


### PR DESCRIPTION
Small change to show the name of a public properties as inline code instead of as "normal" text.

Includes updated unit test.

Note: I've made a minor simplification to the unit test: by using a NowDoc instead of a HereDoc, the `$`-character no longer needs to be escaped.