### PR TITLE
More slash normalization

### DIFF
--- a/src/Parser/SniffParser.php
+++ b/src/Parser/SniffParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Parser;
 
 use App\Parser\Exception\NotASniffPath;
+use App\Util\Functions;
 use App\Value\Diff;
 use App\Value\Property;
 use App\Value\Sniff;
@@ -27,7 +28,7 @@ class SniffParser
 {
     public function parse(string $phpFilePath, SourceLocator $projectSourceLocator): Sniff
     {
-        $phpFilePath = $this->normalizeSlashes($phpFilePath);
+        $phpFilePath = Functions::normalizeSlashes($phpFilePath);
         $astLocator = (new BetterReflection())->astLocator();
         $reflector = new ClassReflector(
             new AggregateSourceLocator([
@@ -211,17 +212,5 @@ class SniffParser
         }, $links);
 
         return new UrlList(array_merge($urls, $xmlUrls));
-    }
-
-    /**
-     * Normalizes all slashes in a file path to forward slashes.
-     *
-     * @param string $path File path.
-     *
-     * @return string The file path with normalized slashes.
-     */
-    private function normalizeSlashes($path)
-    {
-        return str_replace('\\', '/', $path);
     }
 }

--- a/src/Parser/ViolationParser.php
+++ b/src/Parser/ViolationParser.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace App\Parser;
 
 use App\Parser\Exception\NotAViolationPath;
+use App\Util\Functions;
 use App\Value\Diff;
 use App\Value\Url;
 use App\Value\UrlList;
@@ -27,6 +28,7 @@ class ViolationParser
 
     private function getErrorCode(string $xmlFilePath): string
     {
+        $xmlFilePath = Functions::normalizeSlashes($xmlFilePath);
         $part = '([^\/]*)';
         preg_match("/$part\/Docs\/$part\/{$part}Standard\/$part\.xml/", $xmlFilePath, $matches);
         if ($matches === []) {

--- a/src/Util/Functions.php
+++ b/src/Util/Functions.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Util;
+
+class Functions
+{
+
+    /**
+     * Normalizes all slashes in a file path to forward slashes.
+     *
+     * @param string $path File path.
+     *
+     * @return string The file path with normalized slashes.
+     */
+    public static function normalizeSlashes(string $path)
+    {
+        return str_replace('\\', '/', $path);
+    }
+}

--- a/tests/Util/FunctionsTest.php
+++ b/tests/Util/FunctionsTest.php
@@ -1,0 +1,50 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Utils;
+
+use App\Util\Functions;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \App\Util\Functions */
+class FunctionsTest extends TestCase
+{
+
+    /**
+     * Verify slash normalization.
+     *
+     * @dataProvider dataNormalizeSlashes
+     *
+     * @param string $input    Path to normalize.
+     * @param string $expected Expected normalized path.
+     *
+     * @return void
+     */
+    public function testNormalizeSlashes($input, $expected)
+    {
+        self::assertSame($expected, Functions::normalizeSlashes($input));
+    }
+
+    /**
+     * Data provider.
+     *
+     * @return array
+     */
+    public function dataNormalizeSlashes()
+    {
+        return [
+            'unix_slashes' => [
+                'path/to/folder/filename.php',
+                'path/to/folder/filename.php',
+            ],
+            'windows_slashes' => [
+                'path\to\folder\filename.php',
+                'path/to/folder/filename.php',
+            ],
+            'mixed_slashes' => [
+                'path\to/folder\filename.php',
+                'path/to/folder/filename.php',
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
### Move normalizeSlashes() to Util\Functions class

Follow up on #5

When trying to run the full test suite on Windows, I ran into more issues with mixed slashes.

As that means that the `normalizeSlashes()` functionality is needed in more places, I'm proposing to introduce a generic `Util\Functions` class for simple static methods which are needed in multiple places.

Includes introducing dedicated tests for the `normalizeSlashes()` method.

_I'd be happy to rename/move the class if you can think of a better name/path for it._

### ViolationParser: implement use of Functions::normalizeSlashes()

Improves cross-platform compatibility of the code.

With this additional change, the tests will pass on Windows as well, meaning that this part of the functionality should now also work on Windows.

