### PR TITLE
Add JekyllPageGenerator

### DIFF
--- a/src/Generator/JekyllPageGenerator.php
+++ b/src/Generator/JekyllPageGenerator.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Generator;
+
+use App\Value\Sniff;
+
+class JekyllPageGenerator extends MarkdownGenerator implements Generator
+{
+    public function createSniffDoc(Sniff $sniff): string
+    {
+        $sniffDoc = $this->getFrontMatter($sniff) . "\n";
+        $sniffDoc .= parent::createSniffDoc($sniff);
+
+        return $sniffDoc;
+    }
+
+    private function getFrontMatter(Sniff $sniff): string
+    {
+        $sniffName = $sniff->getSniffName();
+        if ($sniffName === '') {
+            return <<<'MD'
+            ---
+            ---
+
+            MD;
+        }
+
+        return <<<MD
+        ---
+        title: {$sniffName}
+        ---
+
+        MD;
+    }
+}

--- a/src/Value/Sniff.php
+++ b/src/Value/Sniff.php
@@ -8,6 +8,9 @@ use Assert\Assert;
 class Sniff
 {
     private string $code;
+    private string $standardName;
+    private string $categoryName;
+    private string $sniffName;
     private string $docblock;
     /**
      * @var Property[]
@@ -42,6 +45,11 @@ class Sniff
         Assert::that($code)
             ->notBlank();
 
+        $sniffNameParts = explode('.', $code);
+        Assert::that($sniffNameParts)
+            ->isArray()
+            ->count(3);
+
         Assert::thatAll($properties)
             ->isInstanceOf(Property::class);
 
@@ -52,6 +60,9 @@ class Sniff
             ->isInstanceOf(Violation::class);
 
         $this->code = $code;
+        $this->standardName = $sniffNameParts[0];
+        $this->categoryName = $sniffNameParts[1];
+        $this->sniffName = $sniffNameParts[2];
         $this->docblock = $docblock;
         $this->properties = array_values($properties);
         $this->urls = $urls;
@@ -63,6 +74,21 @@ class Sniff
     public function getCode(): string
     {
         return $this->code;
+    }
+
+    public function getStandardName(): string
+    {
+        return $this->standardName;
+    }
+
+    public function getCategoryName(): string
+    {
+        return $this->categoryName;
+    }
+
+    public function getSniffName(): string
+    {
+        return $this->sniffName;
     }
 
     public function getDocblock(): string

--- a/tests/Generator/JekyllPageGeneratorTest.php
+++ b/tests/Generator/JekyllPageGeneratorTest.php
@@ -1,0 +1,46 @@
+<?php
+declare(strict_types=1);
+
+namespace App\Tests\Generator;
+
+use App\Generator\JekyllPageGenerator;
+use App\Value\Sniff;
+use App\Value\UrlList;
+use PHPUnit\Framework\TestCase;
+
+/** @covers \App\Generator\JekyllPage */
+class JekyllPageTest extends TestCase
+{
+    private JekyllPageGenerator $generator;
+
+    /** @test */
+    public function fromSniff_WithMinimalData_WriteMinimalDetails()
+    {
+        $doc = new Sniff(
+            'Standard.Category.My',
+            '',
+            [],
+            new UrlList([]),
+            '',
+            [],
+            []
+        );
+
+        self::assertSame(
+            <<<MD
+            ---
+            title: My
+            ---
+
+            # Standard.Category.My
+
+            MD,
+            $this->generator->createSniffDoc($doc)
+        );
+    }
+
+    protected function setUp(): void
+    {
+        $this->generator = new JekyllPageGenerator();
+    }
+}

--- a/tests/Value/SniffTest.php
+++ b/tests/Value/SniffTest.php
@@ -16,6 +16,9 @@ use PHPUnit\Framework\TestCase;
 class SniffTest extends TestCase
 {
     const CODE = 'Standard.Category.Code';
+    const STANDARD = 'Standard';
+    const CATEGORY = 'Category';
+    const SNIFFNAME = 'Code';
     const DOCBLOCK = 'Docblock';
     const DESCRIPTION = 'Description';
     /**
@@ -125,6 +128,33 @@ class SniffTest extends TestCase
         self::assertEquals(
             self::CODE,
             $this->createSniff()->getCode()
+        );
+    }
+
+    /** @test */
+    public function getStandardName()
+    {
+        self::assertSame(
+            self::STANDARD,
+            $this->createSniff()->getStandardName()
+        );
+    }
+
+    /** @test */
+    public function getCategoryName()
+    {
+        self::assertSame(
+            self::CATEGORY,
+            $this->createSniff()->getCategoryName()
+        );
+    }
+
+    /** @test */
+    public function getSniffName()
+    {
+        self::assertSame(
+            self::SNIFFNAME,
+            $this->createSniff()->getSniffName()
         );
     }
 


### PR DESCRIPTION
### Sniff: add getter for the standard, category and sniff name

Includes tests.

### Add JekyllPageGenerator

Jekyll is the underlying technology used for GitHub Pages. Jekyll parses markdown and liquid files to HTML pages for a site.

Generally Jekyll expects "frontmatter" - a `---` delimited block at the top of the markdown file -.
The existence of the frontmatter indicates to Jekyll that the page should be _processed_ by the transformation engine and not just copied over.
Frontmatter also allows for adding variables to the page which can be used in the page/theme to do certain things.

Even though for GitHub Pages, a plugin is active which make the frontmatter not _strictly_ necessary, for this "PHPCS docs" type of website it is useful.

By default, the first `#` (H1) header will be regarded as the `page.title` and this page title is then subsequently used in the website menu and such.

As for these sniff pages, the default title is the full sniffname `Standard.Category.SniffName` and the `Standard` and `Category` are already "levels" in a typical menu due to the folder structure, it is less noisy to use just the plain `SniffName` as the `page.title`.

To that end, I'm adding a separate `JekyllPageGenerator` class which extends the standard `MarkdownGenerator` class and adds the _frontmatter_ to the page.

This will also allow for extending the available frontmatter with additional keys in the future if deemed necessary.

Includes test.

