### PR TITLE
GH Actions: set error reporting to E_ALL

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: 7.4.3
+          ini-values: error_reporting=E_ALL, display_errors=On
       - name: Install composer dependencies
         run: composer install
       - name: Run PHPUnit


### PR DESCRIPTION
Turns out the default setting for `error_reporting` used by the SetupPHP action is `error_reporting=E_ALL & ~E_DEPRECATED & ~E_STRICT` and `display_errors` is set to `Off`.

For the purposes of CI, I'd recommend running with `E_ALL` and `display_errors=On` to ensure **all** PHP notices are shown.